### PR TITLE
Align image folder usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ env/
 
 # Diretórios de dados processados
 images/
-image/
 obsidian_notes/**/*.md
 vault/
 

--- a/scripts/auto_indexer.py
+++ b/scripts/auto_indexer.py
@@ -2,7 +2,7 @@
 """
 Auto Indexador - Monitora a pasta de imagens e indexa automaticamente novos JSONs no ChromaDB
 
-Este script monitora a pasta 'image' por novos arquivos JSON gerados pelo OCR
+Este script monitora a pasta 'images' por novos arquivos JSON gerados pelo OCR
 e os indexa automaticamente no ChromaDB.
 """
 
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 def setup():
     """Configura o ambiente e verifica dependências"""
     # Verificar se o diretório de imagens existe
-    image_dir = ROOT_DIR / "image"
+    image_dir = ROOT_DIR / "images"
     if not image_dir.exists():
         logger.error(f"❌ Diretório de imagens não encontrado: {image_dir}")
         sys.exit(1)

--- a/scripts/example_chroma_indexer.py
+++ b/scripts/example_chroma_indexer.py
@@ -24,7 +24,7 @@ def main():
     print("=" * 50)
     
     # Exemplo 1: Carregar e indexar um arquivo JSON usando a função de conveniência
-    json_dir = ROOT_DIR / "image"
+    json_dir = ROOT_DIR / "images"
     json_files = list(json_dir.glob("*.json"))
     
     if not json_files:

--- a/scripts/test_chroma_indexer.py
+++ b/scripts/test_chroma_indexer.py
@@ -36,7 +36,7 @@ def test_indexing_with_real_files():
     )
     
     # Diretório com arquivos JSON para teste
-    json_dir = ROOT_DIR / "image"
+    json_dir = ROOT_DIR / "images"
     
     # Encontrar todos os arquivos JSON no diretório
     json_files = list(json_dir.glob("*.json"))
@@ -118,7 +118,7 @@ def test_convenience_function():
     print("\n🧪 Testando função de conveniência index_note_in_chroma...")
     
     # Carregar um arquivo JSON de exemplo
-    json_dir = ROOT_DIR / "image"
+    json_dir = ROOT_DIR / "images"
     json_files = list(json_dir.glob("*.json"))
     
     if not json_files:

--- a/src/ocr_extractor.py
+++ b/src/ocr_extractor.py
@@ -33,7 +33,7 @@ except ImportError:
         print("⚠️ Aviso: ChromaIndexer não encontrado. A indexação semântica não estará disponível.")
 
 MODEL_NAME = "gpt-4o"  # modelo atual com suporte a visão
-IMAGE_DIR = Path(__file__).parent.parent / "image"  # Diretório para salvar imagens (raiz do projeto)
+IMAGE_DIR = Path(__file__).parent.parent / "images"  # Diretório para salvar imagens (raiz do projeto)
 PROCESSED_NOTES_FILE = Path(__file__).parent.parent / ".processed_notes.json"  # Arquivo para registro de notas processadas
 
 # Flag para controlar a indexação no ChromaDB
@@ -200,7 +200,7 @@ def main():
     # Verificar argumentos
     if len(sys.argv) == 1:
         # Modo local - usar a imagem padrão
-        img_path = Path(__file__).parent / "image" / "ink.png"
+        img_path = Path(__file__).parent / "images" / "ink.png"
         print(f"🖼️ Modo Local: Usando imagem padrão: {img_path}")
         process_single_image(str(img_path))
     elif len(sys.argv) == 2 and sys.argv[1] == "--help":


### PR DESCRIPTION
## Summary
- standardize directory references to `images/`
- update auto indexer docstring and paths
- adjust example and test scripts for new folder
- fix image folder constant in OCR extractor
- keep only `images/` entry in `.gitignore`

## Testing
- `python -m py_compile src/ocr_extractor.py scripts/auto_indexer.py scripts/test_chroma_indexer.py scripts/example_chroma_indexer.py`

------
https://chatgpt.com/codex/tasks/task_e_683f5a74752c83298c7a6fe8889679c0